### PR TITLE
Fix (Vue CLI 3+): Configuration Error: Avoid modifying webpack output…

### DIFF
--- a/index.js
+++ b/index.js
@@ -24,6 +24,9 @@ module.exports = (api, options) => {
   const address = require("address");
   const portfinder = require("portfinder");
 
+  options.publicPath =
+      process.env.NODE_ENV === "development" ? "/" : "./";
+
   api.registerCommand(
     "cordova-serve",
     {
@@ -217,10 +220,11 @@ module.exports = (api, options) => {
     }
   );
 
-  api.configureWebpack(config => {
-    config.output.publicPath =
-      process.env.NODE_ENV === "development" ? "/" : "./";
-  });
+  //api.configureWebpack(config => {
+  //  config.output.publicPath =
+  //    process.env.NODE_ENV === "development" ? "/" : "./";
+  //});
+  
   // api.chainWebpack(webpackConfig => {
   //   webpackConfig.module
   //     .rule("fonts")


### PR DESCRIPTION
Fixed my trouble with npm run build:

Building for production... ERROR  Error: 
 
Configuration Error: Avoid modifying webpack output.publicPath directly. Use the "publicPath" option instead.

Error:

Configuration Error: Avoid modifying webpack output.publicPath directly. Use the "publicPath" option instead.

    at validateWebpackConfig (C:\Users\Mirek\Desktop\nomadia.app-client\node_modules\@vue\cli-service\lib\util\validateWebpackConfig.js:32:11)
    at build (C:\Users\Mirek\Desktop\nomadia.app-client\node_modules\@vue\cli-service\lib\commands\build\index.js:143:3)
    at C:\Users\Mirek\Desktop\nomadia.app-client\node_modules\@vue\cli-service\lib\commands\build\index.js:86:13
    at Service.run (C:\Users\Mirek\Desktop\nomadia.app-client\node_modules\@vue\cli-service\lib\Service.js:221:12)
    at Object.<anonymous> (C:\Users\Mirek\Desktop\nomadia.app-client\node_modules\@vue\cli-service\bin\vue-cli-service.js:36:9)
    at Module._compile (internal/modules/cjs/loader.js:759:30)
    at Object.Module._extensions..js (internal/modules/cjs/loader.js:770:10)
    at Module.load (internal/modules/cjs/loader.js:628:32)
    at Function.Module._load (internal/modules/cjs/loader.js:555:12)
    at Function.Module.runMain (internal/modules/cjs/loader.js:822:10)
    at internal/main/run_main_module.js:17:11